### PR TITLE
Add libpg-dev to enable pg_config command

### DIFF
--- a/requirements.apt
+++ b/requirements.apt
@@ -1,0 +1,1 @@
+libpq-dev


### PR DESCRIPTION

[Pivotal Tracker Story - Connect an application to a database](https://www.pivotaltracker.com/story/show/91208412)

This example application requires an additional command (pg_config) which is not present within the ubuntu docker container image. The pg_config command is part of the libpq_dev package.